### PR TITLE
Fix APU pulse sweep behavior

### DIFF
--- a/src/apu.c
+++ b/src/apu.c
@@ -552,6 +552,7 @@ void set_pulse_sweep(Pulse *pulse, uint8_t value) {
     pulse->sweep.counter = pulse->sweep.period;
     pulse->shift = value & PULSE_SHIFT;
     pulse->neg = value & BIT_3;
+    pulse->sweep_reload = 1;
     update_target_period(pulse);
 }
 
@@ -700,6 +701,7 @@ static void init_pulse(Pulse *pulse, uint8_t id) {
     pulse->t.loop = 1;
     pulse->sweep.limit = 0;
     pulse->enabled = 0;
+    pulse->sweep_reload = 0;
 }
 
 static void init_triangle(Triangle *triangle) {
@@ -779,6 +781,12 @@ static void update_target_period(Pulse* pulse) {
 }
 
 static void length_sweep_pulse(Pulse *pulse) {
+    if (pulse->sweep_reload) {
+        // trigger a reload
+        pulse->sweep_reload = 0;
+        pulse->sweep.counter = 0;
+    }
+
     if(clock_divider(&pulse->sweep)) {
         if(pulse->enable_sweep && pulse->shift > 0 && !pulse->mute) {
             pulse->t.period = pulse->target_period;

--- a/src/apu.h
+++ b/src/apu.h
@@ -47,6 +47,7 @@ typedef struct {
     uint8_t enabled;
     uint8_t mute;
     uint16_t target_period;
+    uint8_t sweep_reload;
 } Pulse;
 
 


### PR DESCRIPTION
This pull request fixes the APU's pulse sweep. It makes games, especially homebrew games that use the FamiStudio engine sound, much more accurate to the actual NES.

I did notice that there's an inconsistent timing problem with the APU overall, causing the music to sound lower or higher pitched, but I have no idea where those bugs are.

The relevant page with information about the sweep unit: https://www.nesdev.org/wiki/APU_Sweep